### PR TITLE
Use else-if in Rust read_with_wrap

### DIFF
--- a/life-rust/src/main.rs
+++ b/life-rust/src/main.rs
@@ -42,14 +42,12 @@ impl Matrix {
     pub fn read_with_wrap(&self, mut x: i32, mut y: i32) -> bool {
         if x < 0 {
             x += self.width;
+        } else if x >= self.width {
+            x -= self.width;
         }
         if y < 0 {
             y += self.height;
-        }
-        if x >= self.width {
-            x -= self.width;
-        }
-        if y >= self.height {
+        } else if y >= self.height {
             y -= self.height;
         }
 


### PR DESCRIPTION
Avoids an extra branch if `x` or `y` are negative,
shows some performance improvement.