### PR TITLE
Use constants in count_neighbours loop to skip 0

### DIFF
--- a/life-rust/src/main.rs
+++ b/life-rust/src/main.rs
@@ -66,9 +66,9 @@ impl Matrix {
 
 pub fn count_neighbours(m: &Matrix, x: i32, y: i32) -> u32 {
     let mut count = 0;
-    for row in (y - 1)..=(y + 1) {
-        for col in (x - 1)..=(x + 1) {
-            if (col, row) != (x, y) && m.read_with_wrap(col, row) {
+    for row in -1..=1 {
+        for col in -1..=1 {
+            if (col, row) != (0, 0) && m.read_with_wrap(x+col, y+row) {
                 count += 1;
             }
         }


### PR DESCRIPTION
Rust's loop unrolling kicks in if we loop from `-1` to `1`,
but doesn't appear to if we loop from `y-1` to `y+1`, e.g.

Comparisons with the constant `(0,0)` are also presumably faster.